### PR TITLE
new methods for services created

### DIFF
--- a/app/Http/Controllers/Api/ServiceController.php
+++ b/app/Http/Controllers/Api/ServiceController.php
@@ -4,9 +4,12 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ServiceRequest;
+use App\Models\Action;
+use App\Models\Master;
 use App\Models\Service;
 use App\Traits\ApiResponder;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 use Throwable;
 
 class ServiceController extends Controller
@@ -26,6 +29,12 @@ class ServiceController extends Controller
     {
         try {
             $service = new Service($request->validated());
+
+            if (Auth::user()->cannot('create', $service)) {
+                return $this->handleResponse([
+                    'errors' => ['Нет доступа'],
+                ]);
+            }
 
             $service->save();
 
@@ -57,6 +66,12 @@ class ServiceController extends Controller
 
             $data = $request->validated();
 
+            if (Auth::user()->cannot('update', [$service, $data['salon_id']])) {
+                return $this->handleResponse([
+                    'errors' => ['Нет доступа'],
+                ]);
+            }
+
             $service->update($data);
 
             return $this->handleResponse([
@@ -72,11 +87,139 @@ class ServiceController extends Controller
         try {
             $service = Service::findOrFail($id);
 
+            if (Auth::user()->cannot('delete', $service)) {
+                return $this->handleResponse([
+                    'errors' => ['Нет доступа'],
+                ]);
+            }
+
             $service->delete();
 
             return $this->handleResponse([
                 'service' => $service
             ]);
+        } catch (Throwable $e) {
+            return $this->handleError($e->getCode(), $e->getMessage());
+        }
+    }
+
+    public function getMasters(int $id)
+    {
+        try {
+            $service = Service::findOrFail($id);
+
+            $masters = $service->masters()->get();
+
+            return $this->handleResponse([
+                'masters' => $masters,
+            ]);
+        } catch (Throwable $e) {
+            return $this->handleError($e->getCode(), $e->getMessage());
+        }
+    }
+
+    public function getActions(int $id)
+    {
+        try {
+            $service = Service::findOrFail($id);
+
+            $actions = $service->actions()->get();
+
+            return $this->handleResponse([
+                'actions' => $actions,
+            ]);
+        } catch (Throwable $e) {
+            return $this->handleError($e->getCode(), $e->getMessage());
+        }
+    }
+
+    public function attachMaster(int $id, int $master_id)
+    {
+        try {
+            $service = Service::findOrFail($id);
+
+            if (Auth::user()->cannot('editMasterConnection', [$service, $master_id])) {
+                return $this->handleResponse([
+                    'errors' => ['Нет доступа'],
+                ]);
+            }
+
+            $master = Master::findOrFail($master_id);
+
+            if ($service->salon_id == $master->salon_id) {
+                $service->masters()->attach($master_id);
+            } else {
+                return $this->handleResponse([
+                    'errors' => ['Услуга и мастер должны принадлежать одному салону']
+                ]);
+            }
+
+            return $this->handleResponse([]);
+        } catch (Throwable $e) {
+            return $this->handleError($e->getCode(), $e->getMessage());
+        }
+    }
+
+    public function attachAction(int $id, int $action_id)
+    {
+        try {
+            $service = Service::findOrFail($id);
+
+            if (Auth::user()->cannot('editActionConnection', [$service, $action_id])) {
+                return $this->handleResponse([
+                    'errors' => ['Нет доступа'],
+                ]);
+            }
+
+            $action = Action::findOrFail($action_id);
+
+            if ($service->salon_id == $action->salon_id) {
+                $service->actions()->attach($action_id);
+            } else {
+                return $this->handleResponse([
+                    'errors' => ['Услуга и акция должны принадлежать одному салону']
+                ]);
+            }
+
+            return $this->handleResponse([]);
+        } catch (Throwable $e) {
+            return $this->handleError($e->getCode(), $e->getMessage());
+        }
+    }
+
+    public function detachMaster(int $id, int $master_id)
+    {
+        try {
+            $service = Service::findOrFail($id);
+
+            if (Auth::user()->cannot('editMasterConnection', [$service, $master_id])) {
+                return $this->handleResponse([
+                    'errors' => ['Нет доступа'],
+                ]);
+            }
+
+            $service->masters()->detach($master_id);
+
+            return $this->handleResponse([]);
+        } catch (Throwable $e) {
+            return $this->handleError($e->getCode(), $e->getMessage());
+        }
+    }
+
+    public function detachAction(int $id, int $action_id)
+    {
+        try {
+            $service = Service::findOrFail($id);
+
+            if (Auth::user()->cannot('editActionConnection', [$service, $action_id])) {
+                return $this->handleResponse([
+                    'errors' => ['Нет доступа'],
+                ]);
+            }
+
+            $service->actions()->detach($action_id);
+
+            return $this->handleResponse([]);
         } catch (Throwable $e) {
             return $this->handleError($e->getCode(), $e->getMessage());
         }

--- a/app/Policies/ServicePolicy.php
+++ b/app/Policies/ServicePolicy.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Action;
+use App\Models\Master;
+use App\Models\Salon;
+use App\Models\Service;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
+
+class ServicePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Perform pre-authorization checks.
+     *
+     * @param User $user
+     * @param  string  $ability
+     * @return void|bool
+     */
+    public function before(User $user, $ability)
+    {
+        if ($user->role()->first()->id == 1) {
+            return true;
+        }
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param User $user
+     * @param Service $service
+     * @return Response|bool
+     */
+    public function create(User $user, Service $service)
+    {
+        return $user->id == $service->salon()->first()->user_id;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param User $user
+     * @param Service $service
+     * @return Response|bool
+     */
+    public function update(User $user, Service $service, int $salon_id)
+    {
+        $new_salon = Salon::find($salon_id);
+        return $user->id == $service->salon()->first()->user_id
+            && $user->id == $new_salon->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param User $user
+     * @param Service $service
+     * @return Response|bool
+     */
+    public function delete(User $user, Service $service)
+    {
+        return $user->id == $service->salon()->first()->user_id;
+    }
+
+    /**
+     * Determine whether the user can edit connection with the Master model.
+     *
+     * @param User $user
+     * @param Service $service
+     * @return Response|bool
+     */
+    public function editMasterConnection(User $user, Service $service, int $master_id)
+    {
+        $master = Master::find($master_id);
+        return $user->id == $service->salon()->first()->user_id
+            || $user->id == $master->salon()->first()->user_id;
+    }
+
+    /**
+     * Determine whether the user can edit connection with the Action model.
+     *
+     * @param User $user
+     * @param Service $service
+     * @return Response|bool
+     */
+    public function editActionConnection(User $user, Service $service, int $action_id)
+    {
+        $action = Action::find($action_id);
+        return $user->id == $service->salon()->first()->user_id
+            || $user->id == $action->salon()->first()->user_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,9 +4,11 @@ namespace App\Providers;
 
 use App\Models\Master;
 use App\Models\Salon;
+use App\Models\Service;
 use App\Models\User;
 use App\Policies\MasterPolicy;
 use App\Policies\SalonPolicy;
+use App\Policies\ServicePolicy;
 use App\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Auth\Notifications\VerifyEmail;
@@ -24,6 +26,7 @@ class AuthServiceProvider extends ServiceProvider
         User::class => UserPolicy::class,
         Salon::class => SalonPolicy::class,
         Master::class => MasterPolicy::class,
+        Service::class => ServicePolicy::class,
     ];
 
     /**

--- a/routes/api/services.php
+++ b/routes/api/services.php
@@ -4,6 +4,8 @@ use App\Http\Controllers\Api\ServiceController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [ServiceController::class, 'index'])->name('services.index');
+Route::get('/{id}/masters', [ServiceController::class, 'getMasters'])->name('services.masters');
+Route::get('/{id}/actions', [ServiceController::class, 'getActions'])->name('services.actions');
 Route::get('/{id}', [ServiceController::class, 'show'])->name('services.show');
 
 Route::group([
@@ -11,5 +13,9 @@ Route::group([
 ], function () {
     Route::post('/', [ServiceController::class, 'store'])->name('services.store');
     Route::match(['put', 'patch'], '/{id}', [ServiceController::class, 'update'])->name('services.update');
+    Route::post('/{id}/masters/{master_id}', [ServiceController::class, 'attachMaster'])->name('services.attachMaster');
+    Route::post('/{id}/actions/{action_id}', [ServiceController::class, 'attachAction'])->name('services.attachAction');
+    Route::delete('/{id}/masters/{master_id}', [ServiceController::class, 'detachMaster'])->name('services.detachMaster');
+    Route::delete('/{id}/actions/{action_id}', [ServiceController::class, 'detachAction'])->name('services.detachAction');
     Route::delete('/{id}', [ServiceController::class, 'delete'])->name('services.delete');
 });


### PR DESCRIPTION
Добавлены роуты для услуг:

GET api/services/{id}/masters - для вывода мастеров услуги
GET api/services/{id}/actions - для вывода акций услуги
POST api/services/{id}/masters/{master_id} - для создания связи услуги и мастера
POST api/services/{id}/actions/{action_id} - для создания связи услуги и акции
DELETE api/services/{id}/masters/{master_id} - для удаления связи услуги и мастера
DELETE api/services/{id}/actions/{action_id} - для удаления связи услуги и акции