### PR TITLE
Правка вывода отсутствующих изображений

### DIFF
--- a/app/Services/ImageUploadService.php
+++ b/app/Services/ImageUploadService.php
@@ -91,8 +91,12 @@ class ImageUploadService implements UploadImageServiceContract
                     return 'thumbnail/' . $newImage;
                 }
 
-                $thumbnail = Image::make($originDir . 'noimage.gif');
-                $newImage = 'noimage-' . $width . 'x' . $height . '.gif';
+                try {
+                    $thumbnail = Image::make($originDir . 'noimage.gif');
+                    $newImage = 'noimage-' . $width . 'x' . $height . '.gif';
+                } catch (Throwable $e) {
+                    return false;
+                }
             }
 
             $thumbnail->fit($width, $height);


### PR DESCRIPTION
Если нужного изображения нет на месте и файла noimage.gif в папке storage/app/images/origin тоже нет, выдавало ошибку 500. Теперь вместо него выводит /images/ и ошибки 500 нет.